### PR TITLE
disable 5090

### DIFF
--- a/lib/pricing.json
+++ b/lib/pricing.json
@@ -37,7 +37,7 @@
     "vram": "32",
     "region": "Global",
     "price": "$0.61/hr",
-    "available": true
+    "available": false
   },
   {
     "model": "RTX 3090",


### PR DESCRIPTION
Disable 5090 to rent. But doesn't remove it from list.
Reason: it's quite an attractive choice for individual devs in training(cause it's latest).